### PR TITLE
Fix 5.0 Error

### DIFF
--- a/operators/crop_operators.py
+++ b/operators/crop_operators.py
@@ -640,7 +640,7 @@ class EASYCROP_OT_crop(bpy.types.Operator):
         current_frame = scene.frame_current
         strips = []
         
-        for strip in scene.sequence_editor.sequences:
+        for strip in scene.sequence_editor.strips:
             if is_strip_visible_at_frame(strip, current_frame):
                 strips.append(strip)
         
@@ -749,7 +749,7 @@ class EASYCROP_OT_select_and_crop(bpy.types.Operator):
         current_frame = scene.frame_current
         strips = []
         
-        for strip in scene.sequence_editor.sequences:
+        for strip in scene.sequence_editor.strips:
             if is_strip_visible_at_frame(strip, current_frame):
                 strips.append(strip)
         


### PR DESCRIPTION
In blender 5.0 in source and python code many `seq` or `sequence` references got renamed to `strip` or `strips`. This just updates this in the add-on. 
The PR changes `change sequence_editor.sequences` to `sequence_editor.strips`