### PR TITLE
Adjust Keymap to don't interfere with 5.0 default Keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 BL Easy Crop lets you click and drag handles to crop in Blender's Visual Sequence Editor / preview window.
 With this extension Blender's built-in crop looks and behaves a bit more like the other transforms: rotate, scale, move and transform.
-It can be accessed via the preview window toolbar, menus or keyboard shortcut (default "C").
+It can be accessed via the preview window toolbar, menus or keyboard shortcut (default "Shift + C").
 
 Credit to the old https://github.com/doakey3/VSE_Transform_Tools for numerous bits of help while trying to get this thing to work.
 

--- a/__init__.py
+++ b/__init__.py
@@ -198,7 +198,7 @@ def register():
         km = kc.keymaps.new(name=keymap_name, space_type="SEQUENCE_EDITOR", region_type="WINDOW")
 
         # Crop operator - C key (modal for quick access, returns to previous tool)
-        kmi = km.keymap_items.new("sequencer.crop", 'C', 'PRESS')
+        kmi = km.keymap_items.new("sequencer.crop", 'C', 'PRESS', shift=True)
         addon_keymaps.append((km, kmi))
 
         # Clear crop operator - Alt+C key

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -32,7 +32,7 @@ description = """A simplified cropping interface for the built-in crop in Blende
 Features:
 • Crop looks and behaves a bit more like the other transforms (rotate, resize, move, transform)
 • Click and drag handles to crop in the VSE Preview window
-• Select the crop tool via toolbar, menu or shortcut (default "C")
+• Select the crop tool via toolbar, menu or shortcut (default "Shift + C")
 • Respects user's custom-keybinds
 • Works with all strip types that support cropping
 """


### PR DESCRIPTION
In 5.0 the select circle got added to the VSE preview, that tool also uses the C shortcut. This PR changes the crop tool shortcut to 'Shift + C', that way it no longer prevents the user from using the select circle.